### PR TITLE
Uān RealmSwift pán-pún lâi kái-kuat RLMException ē būn-tê

### DIFF
--- a/ChhoeTaigi_iOS/ChhoeTaigi/SearchAll/SearchAllViewController.swift
+++ b/ChhoeTaigi_iOS/ChhoeTaigi/SearchAll/SearchAllViewController.swift
@@ -132,7 +132,7 @@ class SearchAllViewController: UIViewController, UITableViewDataSource, UITableV
             textfield.clipsToBounds = true
             textfield.textColor = #colorLiteral(red: 0.2745098174, green: 0.4862745106, blue: 0.1411764771, alpha: 1)
             
-            if let label = textfield.value(forKey: "_placeholderLabel") as? UILabel {
+            if let label = textfield.value(forKey: "placeholderLabel") as? UILabel {
                 label.minimumScaleFactor = 0.8
                 label.adjustsFontSizeToFitWidth = true
             }

--- a/ChhoeTaigi_iOS/Podfile
+++ b/ChhoeTaigi_iOS/Podfile
@@ -10,7 +10,7 @@ target 'ChhoeTaigi' do
     pod 'Crashlytics'
 
     # Realm
-    pod 'RealmSwift'
+    pod 'RealmSwift', '~> 3.0'
 
     # RxSwift
     pod 'RxSwift'

--- a/ChhoeTaigi_iOS/Podfile.lock
+++ b/ChhoeTaigi_iOS/Podfile.lock
@@ -83,11 +83,11 @@ PODS:
   - nanopb/decode (0.3.901)
   - nanopb/encode (0.3.901)
   - Protobuf (3.6.1)
-  - Realm (3.11.1):
-    - Realm/Headers (= 3.11.1)
-  - Realm/Headers (3.11.1)
-  - RealmSwift (3.11.1):
-    - Realm (= 3.11.1)
+  - Realm (3.21.0):
+    - Realm/Headers (= 3.21.0)
+  - Realm/Headers (3.21.0)
+  - RealmSwift (3.21.0):
+    - Realm (= 3.21.0)
   - RxCocoa (4.3.1):
     - RxSwift (~> 4.0)
   - RxSwift (4.3.1)
@@ -98,7 +98,7 @@ DEPENDENCIES:
   - Fabric
   - Firebase/Core
   - Firebase/Performance
-  - RealmSwift
+  - RealmSwift (~> 3.0)
   - RxCocoa
   - RxSwift
   - Segmentio (~> 3.2)
@@ -127,8 +127,8 @@ SPEC REPOS:
     - Segmentio
 
 SPEC CHECKSUMS:
-  Crashlytics: 1448070c1d2731ab71ea7c3faf84ac0f69657287
-  Fabric: 4ac1cdfef3004ccd83ce0959b91eda8a6e37df72
+  Crashlytics: 89894b46f3d18cede6407d407e8d8e338b9e88a2
+  Fabric: f0e4d56fd1836820d791f1d140c119f336a206dd
   Firebase: b48f9e653da971ecce5b8c749684bc8bb2d26bd3
   FirebaseABTesting: 1f50b8d50f5e3469eea54e7463a7b7fe221d1f5e
   FirebaseAnalytics: 63202d2665de4e6adcbdce189135255d8b5962ba
@@ -142,12 +142,12 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 0c4baf0a73acd0041bf9f71ea018deedab5ea84e
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
   Protobuf: 1eb9700044745f00181c136ef21b8ff3ad5a0fd5
-  Realm: 037c5919b9ceb59d6beed5d3b031096856b119b3
-  RealmSwift: c9580133e73ef40ed340401af2dbc9a5790dfea7
+  Realm: 38e9dcb19104b58407167d99f70d4995f7c16023
+  RealmSwift: 3183cc1ad48378fbcd634311b22c0e6c44021152
   RxCocoa: 78763c7b07d02455598d9fc3c1ad091a28b73635
   RxSwift: fe0fd770a43acdb7d0a53da411c9b892e69bb6e4
   Segmentio: 4e63f9f7c22a58fba9e589e50f8803fd0a1b18c3
 
-PODFILE CHECKSUM: 18c1aed3793552cd3dc35423fa21ca5288776dd3
+PODFILE CHECKSUM: 31deacc5c9ea4688e55cf7bd6e2062be524af36b
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Sú-iōng Xcode 11/12 ê sî ē tú-tio̍h:

> Terminating app due to uncaught exception 'RLMException',
> reason: 'Primary key property 'identity' does not exist on object 'RealmSwiftPermissionUser''

Kái-iōng RealmSwift 3.16.2 í-siōng pán-pún to̍h ē-īng-tit
https://github.com/realm/realm-cocoa/blob/master/CHANGELOG.md#3162-release-notes-2019-06-14

Līng-guā kái-iōng UITextField's `placeholderLabel` lâi tshú-lí:

> *** Terminating app due to uncaught exception 'NSGenericException',
> reason: 'Access to UITextField's _placeholderLabel ivar is prohibited. This is an application bug'